### PR TITLE
Fix shit pack calc

### DIFF
--- a/packages/functions/src/admin-api/stats.ts
+++ b/packages/functions/src/admin-api/stats.ts
@@ -53,7 +53,9 @@ async function getShitPackOdds(args: {
 				}
 		);
 
-	const bronzesRemaining = remainingCardsInPool.filter((card) => card.totalOfType >= 50).concat(unopenedCards);
+	const bronzesRemaining = remainingCardsInPool
+		.concat(unopenedCards)
+		.filter((card) => card.totalOfType >= 50);
 
 	const oddsOfBronze = bronzesRemaining.length / remainingCardsInPool.length;
 


### PR DESCRIPTION
- Add userlogin entity. Add basic login features to website
- Add improved login screen, fix prefetch issues on logout endpoint
- Update UserConfig appearance
- Update Astro and related dependencies
- Add lookingFor attribute to users
- Add api endpoint for updating the lookingFor
- Upgrade to Astro 3.0, migrate files
- Update site build command
- Rearrange open-packs screen
- Add card pinning to profile
- Add API for current chatters
- Update readme
- Update sst
- Add temporary log to database to better understand why build is failing
- Update graphql version to remove vulnerability
- Fix null types on Astro cookies
- Remove unneeded console log
- Update open-packs layout
- Add online indicator for packs in waiting
- Auto create user profile on login
- Add log to resource
- Fix resource usage
- Move chatters resource into components
- Export isChatters fn
- Fix issue refreshing user access token
- Update login to create users if user is admin
- Fix admin env session
- Change prefetch logout to error
- Update paths available to public
- Update PinCardToProfileButton with Pin icon
- Update user profile features
- Fix formatting on design and instance pages
- Change online indicator
- Fix chatters resource
- Update chatters resource fetching method
- Update chatters resource fetching method
- Fix chatters resource not refreshing
- Fix packs creating for no user if a username is provided but incorrect
- Fix vulnerability
- Fix long names in open-packs screen
- Remove extra login/logout buttons. Make lookingFor more intuitive
- Update alert/notification styles
- Include unopened cards when calculating shit pack percent
- Save the most recent pack opening in localstorage
- Add pack reordering on open-packs screen. Save order between page refresh
- Fix rarity sorting to put full art at the top
- Fix shit pack calc
